### PR TITLE
fix(service): Prevent pulseaudio from exiting when idle

### DIFF
--- a/templates/pulseaudio.service.j2
+++ b/templates/pulseaudio.service.j2
@@ -4,7 +4,7 @@ Description=PulseAudio
 
 [Service]
 ExecStartPre=-/usr/bin/pulseaudio --kill
-ExecStart=/usr/bin/pulseaudio
+ExecStart=/usr/bin/pulseaudio --exit-idle-time=-1
 User={{ pulseaudio_user }}
 Restart=always
 RestartSec=10


### PR DESCRIPTION
This was causing PA restart every few seconds,
causing audible noise on audio interface.